### PR TITLE
Allow fuzzy matching of project names

### DIFF
--- a/sublime.php
+++ b/sublime.php
@@ -2,7 +2,7 @@
 
 // Main configuration
 $inQuery = $argv[1] ?: '';
-$reRowQuery = '/'.preg_quote($inQuery).'.*\.sublime-project$/i';
+$reRowQuery = '/' . implode('.*?', str_split(preg_quote($inQuery))) . '.*\.sublime-project$/i';
 $results = array();
 $cache = "/tmp/alfred2-sublimeprojects.tmp";
 $ttl = 10;


### PR DESCRIPTION
This change allows a fuzzy-ish type matching of the names of projects.
For instance, if you have 3 projects such as:

```
dotfiles
Liferay Dev
Liferay Plugins
```

Typing `de` will give you `dotfiles` and `Liferay Dev`, and typing `lfr` will give you both `Liferay Dev` and `Liferay Plugins`, but doing `ldev` will give you just `Liferay Dev`.
This fits more with how fuzzy matching is done in Sublime and makes it really easy to select projects.
